### PR TITLE
Sort friend list

### DIFF
--- a/latest version/server/info.py
+++ b/latest version/server/info.py
@@ -100,6 +100,7 @@ def get_user_friend(c, user_id):
                     "user_id": i[0]
                 })
 
+    s.sort(key=lambda item: item["recent_score"][0]["time_played"] if len(item["recent_score"]) > 0 else 0, reverse=True)
     return s
 
 


### PR DESCRIPTION
The friend list is not sorted.

This PR sorts the friend list before returning. The keyword is the recent play's time just like the official server.