### PR TITLE
[enhance] sql efficiency

### DIFF
--- a/latest version/core/score.py
+++ b/latest version/core/score.py
@@ -559,18 +559,16 @@ class Potential:
     def select_recent_30_tuple(self) -> None:
         '''获取用户recent30数据'''
         self.c.execute(
-            '''select r_index, song_id, difficulty, rating from recent30 where user_id = ? order by time_played DESC''', (self.user.user_id,))
+            '''select r_index, song_id, difficulty, rating from recent30 where user_id = ? and song_id != '' order by time_played DESC''', (self.user.user_id,))
 
-        self.r30_tuples = [x for x in self.c.fetchall() if x[1] != '']
+        self.r30_tuples = self.c.fetchall()
 
     def select_recent_30(self) -> None:
         self.c.execute(
-            '''select song_id, difficulty, score, shiny_perfect_count, perfect_count, near_count, miss_count, health, modifier, time_played, clear_type, rating from recent30 where user_id = ? order by time_played DESC''', (self.user.user_id,))
+            '''select song_id, difficulty, score, shiny_perfect_count, perfect_count, near_count, miss_count, health, modifier, time_played, clear_type, rating from recent30 where user_id = ? and song_id != '' order by time_played DESC''', (self.user.user_id,))
 
         self.r30 = []
         for x in self.c.fetchall():
-            if x[0] == '':
-                continue
             s = Score()
             s.song.set_chart(x[0], x[1])
             s.set_score(*x[2:-1])


### PR DESCRIPTION
在阅读您源码的时候发现，这里的 sql 可能可以优化
```py
        self.c.execute(
            '''select r_index, song_id, difficulty, rating from recent30 where user_id = ? order by time_played DESC''', (self.user.user_id,))

        self.r30_tuples = [x for x in self.c.fetchall() if x[1] != '']
```
从数据库里面选出来再从 python 的 for 循环里排掉，不如直接在 sql 里面加上一句 ... where user_id = ? **and song_id != ''**，这样从数据库读的东西更少，处理效率也更高一些。

您欢迎关于这方面的 pr 吗？我最近正在完整阅读您的源码，如果您愿意，后面可能还会有这样的 pr