### PR TITLE
[Bug fix] Bundle download

### DIFF
--- a/latest version/core/bundle.py
+++ b/latest version/core/bundle.py
@@ -55,7 +55,7 @@ class ContentBundle:
             'contentBundleVersion': self.version,
             'appVersion': self.app_version,
             'jsonSize': self.json_size,
-            'bundleSize': self.bundle_size,
+            'bundleParts': [ { 'bundleSize': self.bundle_size } ]
         }
         if self.json_url and self.bundle_url:
             r['jsonUrl'] = self.json_url

--- a/latest version/core/bundle.py
+++ b/latest version/core/bundle.py
@@ -59,7 +59,7 @@ class ContentBundle:
         }
         if self.json_url and self.bundle_url:
             r['jsonUrl'] = self.json_url
-            r['bundleUrl'] = self.bundle_url
+            r['bundleParts'][0]['bundleUrl'] = self.bundle_url
         return r
 
     def calculate_size(self) -> None:

--- a/latest version/core/config_manager.py
+++ b/latest version/core/config_manager.py
@@ -33,6 +33,7 @@ class Config:
 
     IS_APRILFOOLS = True
 
+    ENABLE_WORLD_RANK = True
     WORLD_RANK_MAX = 200
 
     AVAILABLE_MAP = []  # list[str]

--- a/latest version/core/constant.py
+++ b/latest version/core/constant.py
@@ -34,7 +34,7 @@ class Constant:
     LUNA_UNCAP_BONUS_PROGRESS = 7
     AYU_UNCAP_BONUS_PROGRESS = 5
     SKILL_FATALIS_WORLD_LOCKED_TIME = 3600000
-    SKILL_MIKA_SONGS = ['aprilshowers', 'seventhsense', 'oshamascramble',
+    SKILL_MIKA_SONGS = ['aprilshowers', 'seventhsense', 'oshamascramble', 'breakbreak', 'straightintolights', 'virtus', 'yomibitoshirazu',
                         'amazingmightyyyy', 'cycles', 'maxrage', 'infinity', 'temptation']
     FATALIS_MAX_VALUE = 100
 
@@ -47,7 +47,8 @@ class Constant:
     RECENT10_WEIGHT = Config.RECENT10_WEIGHT
     INVASION_START_WEIGHT = Config.INVASION_START_WEIGHT
     INVASION_HARD_WEIGHT = Config.INVASION_HARD_WEIGHT
-
+    ENABLE_WORLD_RANK = Config.ENABLE_WORLD_RANK
+    
     WORLD_MAP_FOLDER_PATH = Config.WORLD_MAP_FOLDER_PATH
     SONG_FILE_FOLDER_PATH = Config.SONG_FILE_FOLDER_PATH
     SONGLIST_FILE_PATH = Config.SONGLIST_FILE_PATH
@@ -126,7 +127,7 @@ class Constant:
                                                      0x6CB300), (0XA35687B, 0xE456CDEA)
     ]
 
-    DATABASE_MIGRATE_TABLES = ['user', 'friend', 'best_score', 'recent30', 'user_world', 'item', 'user_item', 'purchase', 'purchase_item', 'user_save',
+    DATABASE_MIGRATE_TABLES = ['user', 'friend', 'best_score', 'recent30', 'user_world', 'item', 'user_item', 'purchase', 'purchase_item', 'user_save', 'user_mission',
                                'login', 'present', 'user_present', 'present_item', 'redeem', 'user_redeem', 'redeem_item', 'api_login', 'chart', 'user_course', 'user_char', 'user_role']
 
     LOG_DATABASE_MIGRATE_TABLES = ['cache', 'user_score', 'user_rating']

--- a/latest version/core/system.py
+++ b/latest version/core/system.py
@@ -14,6 +14,6 @@ class GameInfo:
             "core_exp": Constant.CORE_EXP,
             "curr_ts": int(time()*1000),
             "level_steps": [{'level': k, 'level_exp': v} for k, v in Constant.LEVEL_STEPS.items()],
-            "world_ranking_enabled": True,
+            "world_ranking_enabled": Constant.ENABLE_WORLD_RANK,
             "is_byd_chapter_unlocked": True
         }


### PR DESCRIPTION
- Changed bundleSize schema; they changed since v6.12.10.
- Added ENABLE_WORLD_RANK; just in case someone doesn't like having shitty `#1` ass next to the nameplate.
- Added missing maimai song IDs for SKILL_MIKA_VALUE.
- Added missing `user_mission` database migration, which caused blowing up the user mission progress after each single server update.